### PR TITLE
Adding UPF dataset conversion files

### DIFF
--- a/src/computer_vision/upf_branch_conversion/convert_model.py
+++ b/src/computer_vision/upf_branch_conversion/convert_model.py
@@ -1,0 +1,42 @@
+import cv2
+
+##This script detects faces in each frame of the video
+##using the Haar cascade classifier, extracts the faces, and saves them as individual image files.
+
+##can be altered to detect instruments and limbs (object detection --> YOLO)
+
+## Replace "input_video.mp4" with the path to video file 
+## and "haarcascade_frontalface_default.xml" with the path 
+## to the XML file containing the pre-trained face detection model  --> 
+def main():
+    cap = cv2.VideoCapture('input_video.mp4')
+    if not cap.isOpened():
+        print("Error opening video file")
+        return
+
+    face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
+
+    frame_count = 0
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        faces = face_cascade.detectMultiScale(gray, 1.1, 4)
+
+        for (x, y, w, h) in faces:
+            face_roi = frame[y:y+h, x:x+w]
+            cv2.imshow('Face', face_roi)
+            cv2.imwrite(f'face_{frame_count}.jpg', face_roi)
+
+        frame_count += 1
+
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+if __name__ == "__main__":
+    main()

--- a/src/computer_vision/upf_branch_conversion/convert_model.py
+++ b/src/computer_vision/upf_branch_conversion/convert_model.py
@@ -1,37 +1,49 @@
 import cv2
 
-##This script detects faces in each frame of the video
-##using the Haar cascade classifier, extracts the faces, and saves them as individual image files.
+# This script detects faces in each frame of the video
+# using the Haar cascade classifier, extracts the faces, and saves them as individual image files.
 
-##can be altered to detect instruments and limbs (object detection --> YOLO)
+# can be altered to detect instruments and limbs 
 
-## Replace "input_video.mp4" with the path to video file 
-## and "haarcascade_frontalface_default.xml" with the path 
-## to the XML file containing the pre-trained face detection model  --> 
+# Replace "input_video.mp4" with the path to video file 
+# and "haarcascade_frontalface_default.xml" with the path to the XML file containing the pre-trained object detection model
+
 def main():
     cap = cv2.VideoCapture('input_video.mp4')
     if not cap.isOpened():
+        ##unable to open
         print("Error opening video file")
         return
 
     face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
 
     frame_count = 0
+    
+    # The code extracts frames containing faces for every frame in the video
     while True:
         ret, frame = cap.read()
         if not ret:
             break
 
+        # Convert the frame to grayscale for face detection
         gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+        # Detect faces in the grayscale frame
         faces = face_cascade.detectMultiScale(gray, 1.1, 4)
 
+        # For each detected face
         for (x, y, w, h) in faces:
+            # Extract the region of interest (face) from the frame
             face_roi = frame[y:y+h, x:x+w]
+            
+            # Display the extracted face
             cv2.imshow('Face', face_roi)
+            # Save the extracted face as an image file
             cv2.imwrite(f'face_{frame_count}.jpg', face_roi)
 
         frame_count += 1
 
+        # Check for user input to exit loop
         if cv2.waitKey(1) & 0xFF == ord('q'):
             break
 

--- a/src/computer_vision/upf_branch_conversion/extract_images.py
+++ b/src/computer_vision/upf_branch_conversion/extract_images.py
@@ -1,6 +1,6 @@
 import cv2
 
-# This script detects faces in each frame of the video
+# This script detects faces in each frame of a video 
 # using the Haar cascade classifier, extracts the faces, and saves them as individual image files.
 
 # can be altered to detect instruments and limbs 

--- a/src/computer_vision/upf_branch_conversion/extract_images.py
+++ b/src/computer_vision/upf_branch_conversion/extract_images.py
@@ -1,9 +1,9 @@
 import cv2
 
-# This supporting script detects faces in each frame of a video 
-# using the Haar cascade classifier, extracts the faces, and saves them as individual image files.
+# This (supporting) script detects faces in each frame of a video using the Haar cascade classifier, 
+# extracts the faces, and saves them as individual image files.
 
-# can be altered to detect instruments and limbs 
+# Can be altered to detect instruments and limbs using a trained object detection model
 
 # Replace "input_video.mp4" with the path to video file 
 # and "haarcascade_frontalface_default.xml" with the path to the XML file containing the pre-trained object detection model
@@ -19,7 +19,7 @@ def main():
 
     frame_count = 0
     
-    # The code extracts frames containing faces for every frame in the video
+    # Extracts frames containing faces for every frame in the video
     while True:
         ret, frame = cap.read()
         if not ret:

--- a/src/computer_vision/upf_branch_conversion/extract_images.py
+++ b/src/computer_vision/upf_branch_conversion/extract_images.py
@@ -1,6 +1,6 @@
 import cv2
 
-# This script detects faces in each frame of a video 
+# This supporting script detects faces in each frame of a video 
 # using the Haar cascade classifier, extracts the faces, and saves them as individual image files.
 
 # can be altered to detect instruments and limbs 

--- a/src/computer_vision/upf_branch_conversion/upf_coords_to_yolo_pixels.py
+++ b/src/computer_vision/upf_branch_conversion/upf_coords_to_yolo_pixels.py
@@ -2,7 +2,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 
-# We use the Pandas library to read Excel files (which is what the UPF coords are stored in)
+# This program use the Pandas library to read Excel files (which is what the UPF coords are stored in)
 # and Matplotlib library to visualize the coordinates as pixels in an output file.
 
 # Read Excel files

--- a/src/computer_vision/upf_branch_conversion/upf_coords_to_yolo_pixels.py
+++ b/src/computer_vision/upf_branch_conversion/upf_coords_to_yolo_pixels.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+# We use the Pandas library to read Excel files (which is what the UPF coords are stored in)
+# and Matplotlib library to visualize the coordinates as pixels in an output file.
+
+# Read Excel files
+cello_body_df = pd.read_excel('cello_body.xlsx')
+cello_fretboard_df = pd.read_excel('cello_fretboard.xlsx')
+cello_antenna_front_df = pd.read_excel('cello_antenna_front.xlsx')
+cello_antenna_back_df = pd.read_excel('cello_antenna_back.xlsx')
+cellist_df = pd.read_excel('cellist.xlsx')
+
+# Plotting
+plt.figure(figsize=(8, 6))
+
+# Plot cello body
+plt.scatter(cello_body_df['x'], cello_body_df['y'], color='green', label='Cello Body')
+
+# Plot cello fretboard
+plt.scatter(cello_fretboard_df['x'], cello_fretboard_df['y'], color='red', label='Cello Fretboard')
+
+# Plot cello antenna front
+plt.scatter(cello_antenna_front_df['x'], cello_antenna_front_df['y'], color='gray', label='Cello Antenna front')
+
+# Plot cello antenna back
+plt.scatter(cello_antenna_back_df['x'], cello_antenna_back_df['y'], color='black', label='Cello Antenna back')
+
+# Plot cellist
+plt.scatter(cellist_df['x'], cellist_df['y'], color='blue', label='Cellist')
+
+plt.xlabel('X Coordinate')
+plt.ylabel('Y Coordinate')
+plt.title('Cello and Cellist Coordinates')
+plt.legend()
+plt.grid(True)
+
+#Save the image
+plt.savefig('output.png')
+plt.show()


### PR DESCRIPTION
Request to add the following files:

1) upf_coords_to_yolo_pixels.py: This file reads in the coordinates of the parts of a cello from excel sheets and then visualizes them as images that are then saved in png format. The UPF dataset stores the data in terms of coordinates, and YOLO trains on full images.

2) extract_images.py: This is an incomplete support script. It uses a pre-trained model to recognize objects from videos and extract images of these objects. It currently recognizes faces and saves images of these faces, but it can be modified to detect instruments or limbs as well. I stopped working on this once Shrinand's model became functional, but it can be fixed or modified for testing or comparing, and can also be used as a back-up.
